### PR TITLE
Update 中新金盾信息安全管理系统 默认超级管理员密码漏洞.md

### DIFF
--- a/PeiQi_Wiki/Web应用漏洞/中新金盾/中新金盾信息安全管理系统 默认超级管理员密码漏洞.md
+++ b/PeiQi_Wiki/Web应用漏洞/中新金盾/中新金盾信息安全管理系统 默认超级管理员密码漏洞.md
@@ -43,6 +43,7 @@
 > 请求  ?q=common/getcode  时
 >
 > 返回了验证码，通过验证码可爆破账号密码等操作
+> 爆破时也可让check_code保持四位字母，Cookie和Body中数据一致就OK
 
 ![](image/zxjd-6.png)
 

--- a/PeiQi_Wiki/Web应用漏洞/中新金盾/中新金盾信息安全管理系统 默认超级管理员密码漏洞.md
+++ b/PeiQi_Wiki/Web应用漏洞/中新金盾/中新金盾信息安全管理系统 默认超级管理员密码漏洞.md
@@ -43,6 +43,7 @@
 > 请求  ?q=common/getcode  时
 >
 > 返回了验证码，通过验证码可爆破账号密码等操作
+> 
 > 爆破时也可让check_code保持四位字母，Cookie和Body中数据一致就OK
 
 ![](image/zxjd-6.png)


### PR DESCRIPTION
复现发现爆破或者登录的时候只要保持Cookie和Body中的check_code一致也可以